### PR TITLE
Preserve section content across templates and enhance export save flow

### DIFF
--- a/assets/js/controllers/fileController.js
+++ b/assets/js/controllers/fileController.js
@@ -1,32 +1,70 @@
 import { sanitizeFilename } from '../utils/stringUtils.js';
 
-async function saveFile({ payload, suggestedName }) {
-  if (window.showSaveFilePicker) {
-    try {
-      const handle = await window.showSaveFilePicker({
-        suggestedName,
-        types: [{ description: 'Archivo JSON', accept: { 'application/json': ['.json'] } }]
-      });
-      const writable = await handle.createWritable();
-      await writable.write(payload);
-      await writable.close();
-      return;
-    } catch (error) {
-      if (error?.name === 'AbortError') {
-        return;
-      }
-      console.error('Error al exportar archivo', error);
-      alert('No se pudo exportar el archivo. Intente nuevamente.');
-      return;
-    }
+async function saveWithFilePicker({ payload, suggestedName }) {
+  if (!window.showSaveFilePicker) {
+    return false;
   }
 
+  try {
+    const handle = await window.showSaveFilePicker({
+      suggestedName,
+      types: [{ description: 'Archivo JSON', accept: { 'application/json': ['.json'] } }]
+    });
+    const writable = await handle.createWritable();
+    await writable.write(payload);
+    await writable.close();
+    return true;
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      return true;
+    }
+    console.error('Error al exportar archivo', error);
+    alert('No se pudo exportar el archivo. Intente nuevamente.');
+    return false;
+  }
+}
+
+async function saveWithDirectoryPicker({ payload, suggestedName }) {
+  if (!window.showDirectoryPicker) {
+    return false;
+  }
+
+  try {
+    const directoryHandle = await window.showDirectoryPicker();
+    const fileHandle = await directoryHandle.getFileHandle(suggestedName, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(payload);
+    await writable.close();
+    return true;
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      return true;
+    }
+    console.error('Error al exportar archivo', error);
+    alert('No se pudo exportar el archivo. Intente nuevamente.');
+    return false;
+  }
+}
+
+function downloadWithAnchor({ payload, suggestedName }) {
   const blob = new Blob([payload], { type: 'application/json' });
   const anchor = document.createElement('a');
   anchor.href = URL.createObjectURL(blob);
   anchor.download = suggestedName;
   anchor.click();
   setTimeout(() => URL.revokeObjectURL(anchor.href), 2000);
+}
+
+async function saveFile({ payload, suggestedName }) {
+  if (await saveWithFilePicker({ payload, suggestedName })) {
+    return;
+  }
+
+  if (await saveWithDirectoryPicker({ payload, suggestedName })) {
+    return;
+  }
+
+  downloadWithAnchor({ payload, suggestedName });
 }
 
 function ensureJsonExtension(name) {

--- a/assets/js/controllers/sectionController.js
+++ b/assets/js/controllers/sectionController.js
@@ -63,3 +63,40 @@ export function collectSections(container) {
     content: section.querySelector('textarea')?.value || ''
   }));
 }
+
+export function hydrateSections(container, sections = []) {
+  if (!Array.isArray(sections) || sections.length === 0) {
+    return;
+  }
+
+  const existingSections = Array.from(container.querySelectorAll('.sec[data-section]'));
+  sections.forEach((section, index) => {
+    if (!section || typeof section !== 'object') {
+      return;
+    }
+
+    const target = existingSections[index];
+    const title = (section.title ?? '').trim();
+    const content = section.content ?? '';
+
+    if (target) {
+      const subtitle = target.querySelector('.subtitle');
+      if (subtitle && title) {
+        subtitle.innerText = title;
+      }
+
+      const textarea = target.querySelector('textarea');
+      if (textarea) {
+        textarea.value = String(content);
+      }
+      return;
+    }
+
+    const extraSection = createSectionElement({
+      title: title || 'Sección personalizada',
+      content: String(content)
+    });
+    container.appendChild(extraSection);
+    existingSections.push(extraSection);
+  });
+}


### PR DESCRIPTION
## Summary
- preserve user-entered section content when switching templates by tracking state and hydrating sections with previous values
- add a section hydration helper so overflowing content is appended instead of lost when templates change
- enhance JSON export so compatible browsers open a save dialog (including directory picker fallback) before falling back to automatic download

## Testing
- Not run (UI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138260af14832c957469a9f618956f)