### PR TITLE
feat: add ai assistant panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Aplicación web liviana para gestionar y documentar la evolución clínica de pa
 - **Plantillas dinámicas**: selector de tipo de informe con títulos autogenerados y estructuras preconfiguradas.
 - **Importación / exportación**: persistencia del formulario completo en JSON con nombres de archivo sugeridos.
 - **Impresión profesional**: título y nombre del archivo ajustados automáticamente antes de imprimir o guardar en PDF.
+- **Panel IA contextual**: asistente Gemini con flujo dual (conversación y edición puntual) que consume toda la ficha clínica como contexto, con acciones rápidas y aplicación directa del texto propuesto en cada sección.
 
 ## Estructura del proyecto
 
@@ -57,6 +58,13 @@ Cada controlador encapsula una responsabilidad concreta:
 - **Persistencia**: mantenga la compatibilidad del esquema JSON agregando un campo `version` (actualmente `v12`). Documente cualquier cambio en el README.
 - **Estilo de código**: utilice ES Modules, funciones puras cuando sea posible y evite dependencias globales. Prefiera `const` para referencias inmutables.
 - **Pruebas manuales**: verifique siempre los flujos de exportación, importación y actualización de títulos tras tocar módulos relacionados.
+
+### Panel IA Gemini
+
+1. Obtenga una API Key válida de Gemini (o credenciales Vertex) y configúrela desde el botón ⚙️ del panel.
+2. Utilice las pestañas **Conversación** o **Editar sección** para definir el flujo. En modo edición puede seleccionar la sección destino y aplicar la propuesta con un clic.
+3. Las preferencias (API Key, modelo, ancho del panel, etc.) se almacenan localmente en el navegador para evitar reingresos.
+4. Si el modelo seleccionado no está disponible, la app intentará elegir automáticamente un fallback compatible.
 
 ## Controles internos y aseguramiento de calidad
 

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -27,8 +27,59 @@ body{ font-family: Arial, sans-serif; font-size: var(--fs); color:#1f2937; backg
 .edit-mode #sec-datos .row .row-del{ display:inline-flex; align-items:center; justify-content:center; background:#ef4444; color:#fff; border:0; border-radius:8px; padding:2px 8px; cursor:pointer; }
 .edit-mode #sec-datos .lbl{ outline:1px dashed #93c5fd; padding:2px 4px; border-radius:4px; }
 
+.ai-drawer{ position:fixed; top:0; right:0; height:100vh; width:400px; max-width:100%; background:#f8fafc; border-left:1px solid #e5e7eb; box-shadow:none; transform:translateX(100%); transition:transform .25s ease, box-shadow .25s ease; z-index:9998; display:flex; }
+.ai-drawer.is-open{ transform:translateX(0); box-shadow:-12px 0 30px rgba(15,23,42,.25); }
+.ai-drawer-inner{ display:flex; flex-direction:column; gap:12px; padding:16px; width:100%; }
+.ai-resize-handle{ position:absolute; top:0; left:-6px; width:6px; height:100%; cursor:col-resize; }
+.ai-drawer-header{ display:flex; align-items:flex-start; justify-content:space-between; gap:12px; }
+.ai-drawer-title{ margin:0; font-size:1.15rem; font-weight:700; color:#0f172a; }
+.ai-drawer-subtitle{ margin:2px 0 0; font-size:.85rem; color:#475569; }
+.ai-header-actions{ display:flex; gap:6px; }
+.ai-close-btn,.ai-ghost-btn{ border:0; background:transparent; border-radius:999px; width:32px; height:32px; display:inline-flex; align-items:center; justify-content:center; cursor:pointer; font-size:1rem; }
+.ai-close-btn:hover{ background:#fee2e2; color:#b91c1c; }
+.ai-ghost-btn{ color:#1d4ed8; }
+.ai-ghost-btn:hover{ background:#e0f2fe; }
+.ai-panel-settings{ background:#fff; border:1px solid #e2e8f0; border-radius:12px; padding:12px; display:none; }
+.ai-panel-settings.is-visible{ display:block; animation:fadeIn .2s ease; }
+.ai-settings-grid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); gap:10px; }
+.ai-field{ display:flex; flex-direction:column; gap:4px; font-size:.8rem; color:#0f172a; }
+.ai-field input,.ai-field select{ border:1px solid #cbd5f5; border-radius:8px; padding:6px 8px; font-size:.85rem; background:#fff; }
+.ai-check{ display:flex; align-items:center; gap:6px; font-size:.8rem; color:#334155; }
+.ai-settings-hint{ margin:8px 0 0; font-size:.75rem; color:#64748b; }
+.ai-tabs{ display:grid; grid-template-columns:repeat(2,1fr); gap:8px; }
+.ai-tab{ border:0; border-radius:10px; padding:10px; font-weight:600; cursor:pointer; background:#e2e8f0; color:#475569; }
+.ai-tab.is-active{ background:#2563eb; color:#fff; box-shadow:0 8px 24px rgba(37,99,235,.3); }
+.ai-section-picker{ display:none; flex-direction:column; gap:4px; font-size:.78rem; color:#312e81; background:#eef2ff; border:1px solid #c7d2fe; border-radius:10px; padding:10px; }
+.ai-section-picker select{ border:1px solid #a5b4fc; border-radius:8px; padding:6px; font-size:.85rem; }
+.ai-section-picker.is-visible{ display:flex; }
+.ai-quick-actions{ display:grid; grid-template-columns:repeat(auto-fit, minmax(120px,1fr)); gap:8px; }
+.ai-quick-actions button{ border:1px solid #e2e8f0; border-radius:10px; background:#fff; padding:8px; font-size:.78rem; color:#0f172a; cursor:pointer; display:flex; align-items:center; justify-content:center; gap:6px; box-shadow:0 1px 2px rgba(0,0,0,.06); }
+.ai-quick-actions button:hover{ border-color:#94a3b8; }
+.ai-quick-actions button:disabled{ opacity:.4; cursor:not-allowed; }
+.ai-messages{ flex:1; overflow-y:auto; border:1px solid #e2e8f0; border-radius:14px; padding:12px; background:#fff; display:flex; flex-direction:column; gap:12px; }
+.ai-message{ max-width:90%; border-radius:18px; padding:10px 14px; font-size:.85rem; line-height:1.45; box-shadow:0 1px 2px rgba(15,23,42,.1); }
+.ai-message.user{ margin-left:auto; background:#1d4ed8; color:#fff; border-bottom-right-radius:6px; }
+.ai-message.assistant{ background:#f8fafc; border:1px solid #dbeafe; color:#0f172a; border-bottom-left-radius:6px; }
+.ai-message .ai-apply{ margin-top:6px; display:inline-flex; align-items:center; gap:4px; border:1px solid #c7d2fe; background:#eef2ff; color:#3730a3; border-radius:999px; padding:4px 10px; font-size:.7rem; cursor:pointer; }
+.ai-message .ai-apply:hover{ background:#d4dcff; }
+.ai-empty{ text-align:center; color:#94a3b8; font-size:.85rem; }
+.ai-empty-icon{ font-size:2rem; margin:0; }
+.ai-empty-hint{ font-size:.75rem; }
+.ai-error{ display:none; margin-top:-4px; color:#b91c1c; font-size:.78rem; border:1px solid #fecaca; background:#fee2e2; border-radius:10px; padding:8px; }
+.ai-error.is-visible{ display:block; }
+.ai-input{ border:1px solid #e2e8f0; border-radius:14px; padding:10px; background:#fff; display:flex; flex-direction:column; gap:8px; }
+.ai-input textarea{ width:100%; border:0; resize:none; font-size:.9rem; line-height:1.4; font-family:inherit; min-height:60px; }
+.ai-input textarea:focus{ outline:none; }
+.ai-send{ align-self:flex-end; border:0; border-radius:999px; padding:8px 16px; background:#2563eb; color:#fff; font-weight:600; cursor:pointer; }
+.ai-send:disabled{ opacity:.5; cursor:not-allowed; }
+.ai-input-hint{ text-align:center; font-size:.7rem; color:#94a3b8; margin:0; }
+.ai-markdown{ line-height:1.6; }
+.ai-loading{ font-size:.8rem; color:#64748b; }
+
+@keyframes fadeIn{ from{ opacity:0; transform:translateY(-4px); } to{ opacity:1; transform:translateY(0); } }
+
 @media print{
-  .topbar, .edit-panel{ display:none !important; }
+  .topbar, .edit-panel, .ai-drawer{ display:none !important; }
   html, body{ height:auto !important; overflow:visible !important; }
   .sheet{ border:none; border-radius:0; padding:14mm; max-width:unset; overflow:visible !important; }
   .txt{ min-height:70px; overflow:visible !important; }

--- a/assets/js/controllers/aiController.js
+++ b/assets/js/controllers/aiController.js
@@ -1,0 +1,602 @@
+import {
+  generateGeminiContent,
+  GeminiModelUnavailableError,
+  suggestGeminiFallbackModel
+} from '../utils/geminiClient.js';
+import { formatAssistantHtml, markdownToPlainText } from '../utils/textUtils.js';
+import { getDefaultGeminiModel } from '../utils/env.js';
+
+const STORAGE_KEY = 'ai-assistant-preferences';
+const PANEL_WIDTH_RANGE = { min: 320, max: 720 };
+
+const CHAT_ACTIONS = [
+  { label: 'Resumen caso', icon: '📋', prompt: 'Genera un resumen clínico completo y estructurado del caso actual.' },
+  { label: 'Análisis crítico', icon: '🔍', prompt: 'Analiza riesgos, brechas diagnósticas y oportunidades de mejora del manejo.' },
+  { label: 'Diferenciales', icon: '🩺', prompt: 'Proporciona diagnósticos diferenciales priorizados con breve justificación.' }
+];
+
+const EDIT_ACTIONS = [
+  { label: 'Resumir', icon: '✂️', prompt: 'Resume el texto de la sección manteniendo los datos clínicos esenciales.' },
+  { label: 'Expandir', icon: '📖', prompt: 'Amplía el texto con mayor detalle técnico sin inventar información.' },
+  { label: 'Mejorar estilo', icon: '✨', prompt: 'Reescribe con redacción profesional, clara y cohesionada.' },
+  { label: 'Corregir', icon: '🔧', prompt: 'Corrige ortografía y formato conservando el significado original.' }
+];
+
+function loadPreferences() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return stored ? JSON.parse(stored) : {};
+  } catch (error) {
+    console.warn('No se pudieron cargar las preferencias del asistente IA.', error);
+    return {};
+  }
+}
+
+function savePreferences(preferences) {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.warn('No se pudieron guardar las preferencias del asistente IA.', error);
+  }
+}
+
+function buildBaseContext({ title, patientFields = [], sections = [], medico = '', especialidad = '' }) {
+  const patientBlock = patientFields
+    .map((field) => `${field.label || field.id}: ${field.value || ''}`)
+    .join('\n');
+  const sectionsBlock = sections
+    .map((section) => `${section.title}\n${section.content}`)
+    .join('\n\n');
+  const medicoBlock = [medico && `Médico tratante: ${medico}`, especialidad && `Especialidad: ${especialidad}`]
+    .filter(Boolean)
+    .join('\n');
+  return `TÍTULO\n${title}\n\nDATOS DEL PACIENTE\n${patientBlock}\n\nSECCIONES CLÍNICAS\n${sectionsBlock}\n\n${medicoBlock}`.trim();
+}
+
+function getPersonaInstructions(profile) {
+  switch (profile) {
+    case 'urgencias':
+      return 'Actúa como un médico de urgencias priorizando el reconocimiento de riesgos vitales y acciones inmediatas.';
+    case 'pediatria':
+      return 'Actúa como pediatra, cuidando la comunicación empática y ajustando dosis o intervenciones por peso y edad.';
+    default:
+      return 'Actúa como internista experimentado con enfoque integral y lenguaje técnico claro.';
+  }
+}
+
+function buildSystemPrompt({ profile, mode, section }) {
+  const persona = getPersonaInstructions(profile);
+  if (mode === 'edit' && section) {
+    return `${persona}\n\nTe enfocas únicamente en editar la sección "${section.title}". Usa la solicitud del usuario como guía, respeta los datos entregados y responde con texto listo para reemplazar la sección.`;
+  }
+  return `${persona}\nOfrece análisis clínico, recomendaciones o documentos apoyándote SIEMPRE en la información proporcionada.`;
+}
+
+function getActionsForMode(mode) {
+  return mode === 'edit' ? EDIT_ACTIONS : CHAT_ACTIONS;
+}
+
+function clampWidth(width) {
+  return Math.min(PANEL_WIDTH_RANGE.max, Math.max(PANEL_WIDTH_RANGE.min, width));
+}
+
+function renderEmptyState({ emptyState, apiKey, mode }) {
+  if (!emptyState) {
+    return;
+  }
+  emptyState.style.display = 'block';
+  const paragraphs = emptyState.querySelectorAll('p');
+  if (!apiKey) {
+    if (paragraphs[1]) {
+      paragraphs[1].textContent = 'Configura tu API Key en ⚙️ para comenzar.';
+    }
+  } else if (mode === 'chat') {
+    if (paragraphs[1]) {
+      paragraphs[1].textContent = 'Pregunta sobre diagnósticos, planes o solicita resúmenes clínicos.';
+    }
+  } else if (paragraphs[1]) {
+    paragraphs[1].textContent = 'Selecciona una sección y pide cómo deseas mejorarla.';
+  }
+}
+
+export function initAIController(options) {
+  const {
+    panel,
+    toggleButton,
+    sectionsContainer,
+    getPatientFields,
+    getSectionsSnapshot,
+    getTitle,
+    getMedico,
+    getEspecialidad,
+    onApplyToSection
+  } = options || {};
+
+  if (!panel || !toggleButton || !sectionsContainer) {
+    return null;
+  }
+
+  const elements = {
+    subtitle: panel.querySelector('[data-ai-subtitle]'),
+    settingsPanel: panel.querySelector('[data-ai-settings]'),
+    settingsToggle: panel.querySelector('[data-ai-settings-toggle]'),
+    apiKey: panel.querySelector('[data-ai-api-key]'),
+    project: panel.querySelector('[data-ai-project]'),
+    model: panel.querySelector('[data-ai-model]'),
+    profile: panel.querySelector('[data-ai-profile]'),
+    markdown: panel.querySelector('[data-ai-markdown]'),
+    autoModel: panel.querySelector('[data-ai-auto-model]'),
+    tabs: panel.querySelectorAll('[data-ai-mode]'),
+    sectionPicker: panel.querySelector('[data-ai-section-picker]'),
+    sectionSelect: panel.querySelector('[data-ai-section-select]'),
+    actions: panel.querySelector('[data-ai-actions]'),
+    messages: panel.querySelector('[data-ai-messages]'),
+    emptyState: panel.querySelector('[data-ai-empty]'),
+    error: panel.querySelector('[data-ai-error]'),
+    input: panel.querySelector('[data-ai-input]'),
+    sendButton: panel.querySelector('[data-ai-send]'),
+    inputArea: panel.querySelector('[data-ai-input-area]'),
+    closeButton: panel.querySelector('[data-ai-close]'),
+    resizer: panel.querySelector('[data-ai-resizer]')
+  };
+
+  const storedPrefs = loadPreferences();
+  const state = {
+    isOpen: false,
+    mode: 'chat',
+    messages: [],
+    isLoading: false,
+    showSettings: Boolean(storedPrefs.showSettings),
+    apiKey: storedPrefs.apiKey || '',
+    projectId: storedPrefs.projectId || '',
+    model: storedPrefs.model || getDefaultGeminiModel(),
+    assistantProfile: storedPrefs.assistantProfile || 'general',
+    allowMarkdown: storedPrefs.allowMarkdown !== false,
+    autoModel: storedPrefs.autoModel !== false,
+    targetSectionIndex: 0,
+    panelWidth: clampWidth(storedPrefs.panelWidth || 400),
+    error: ''
+  };
+
+  function persist() {
+    savePreferences({
+      apiKey: state.apiKey,
+      projectId: state.projectId,
+      model: state.model,
+      assistantProfile: state.assistantProfile,
+      allowMarkdown: state.allowMarkdown,
+      autoModel: state.autoModel,
+      showSettings: state.showSettings,
+      panelWidth: state.panelWidth
+    });
+  }
+
+  function applyPreferencesToInputs() {
+    if (elements.apiKey) {
+      elements.apiKey.value = state.apiKey;
+    }
+    if (elements.project) {
+      elements.project.value = state.projectId;
+    }
+    if (elements.model) {
+      elements.model.value = state.model;
+    }
+    if (elements.profile) {
+      elements.profile.value = state.assistantProfile;
+    }
+    if (elements.markdown) {
+      elements.markdown.checked = state.allowMarkdown;
+    }
+    if (elements.autoModel) {
+      elements.autoModel.checked = state.autoModel;
+    }
+    if (elements.settingsPanel) {
+      elements.settingsPanel.classList.toggle('is-visible', state.showSettings || !state.apiKey);
+    }
+    panel.style.width = `${state.panelWidth}px`;
+  }
+
+  function setMode(mode) {
+    if (state.mode === mode) {
+      return;
+    }
+    state.mode = mode;
+    state.messages = [];
+    setError('');
+    updateTabs();
+    syncQuickActions();
+    renderMessages();
+    updateSubtitle();
+    updateSectionPicker();
+  }
+
+  function updateTabs() {
+    elements.tabs.forEach((tab) => {
+      const tabMode = tab.getAttribute('data-ai-mode');
+      tab.classList.toggle('is-active', tabMode === state.mode);
+    });
+  }
+
+  function updateSubtitle() {
+    if (!elements.subtitle) {
+      return;
+    }
+    elements.subtitle.textContent =
+      state.mode === 'chat' ? 'Analiza el caso clínico completo' : 'Edita la redacción de una sección concreta';
+  }
+
+  function getSectionsData() {
+    return typeof getSectionsSnapshot === 'function' ? getSectionsSnapshot() : [];
+  }
+
+  function updateSectionPicker() {
+    if (!elements.sectionPicker) {
+      return;
+    }
+    const sections = getSectionsData();
+    const showPicker = state.mode === 'edit' && sections.length > 0;
+    elements.sectionPicker.classList.toggle('is-visible', showPicker);
+    if (!showPicker) {
+      return;
+    }
+    elements.sectionSelect.innerHTML = '';
+    sections.forEach((section, index) => {
+      const option = document.createElement('option');
+      option.value = String(index);
+      option.textContent = section.title || `Sección ${index + 1}`;
+      elements.sectionSelect.appendChild(option);
+    });
+    if (state.targetSectionIndex >= sections.length) {
+      state.targetSectionIndex = sections.length - 1;
+    }
+    if (state.targetSectionIndex < 0) {
+      state.targetSectionIndex = 0;
+    }
+    elements.sectionSelect.value = String(state.targetSectionIndex);
+  }
+
+  function syncQuickActions() {
+    if (!elements.actions) {
+      return;
+    }
+    elements.actions.innerHTML = '';
+    const actions = getActionsForMode(state.mode);
+    actions.forEach((action) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = `${action.icon} ${action.label}`;
+      button.disabled = state.isLoading || !state.apiKey;
+      button.addEventListener('click', () => handleSend(action.prompt));
+      elements.actions.appendChild(button);
+    });
+  }
+
+  function toggleDrawer(forceOpen) {
+    const shouldOpen = typeof forceOpen === 'boolean' ? forceOpen : !state.isOpen;
+    state.isOpen = shouldOpen;
+    panel.classList.toggle('is-open', state.isOpen);
+    panel.setAttribute('aria-hidden', String(!state.isOpen));
+    if (state.isOpen) {
+      updateSectionPicker();
+      renderMessages();
+    }
+  }
+
+  function updateSendAvailability() {
+    if (!elements.sendButton || !elements.input) {
+      return;
+    }
+    const hasText = Boolean(elements.input.value.trim());
+    elements.sendButton.disabled = !hasText || state.isLoading || !state.apiKey;
+    elements.input.placeholder =
+      state.mode === 'chat'
+        ? 'Haz una pregunta sobre el caso...'
+        : 'Describe cómo quieres reescribir la sección seleccionada...';
+  }
+
+  function renderMessages() {
+    if (!elements.messages) {
+      return;
+    }
+    elements.messages.innerHTML = '';
+    const showEmpty = !state.messages.length;
+    if (elements.emptyState) {
+      elements.emptyState.style.display = showEmpty ? 'block' : 'none';
+      if (showEmpty) {
+        renderEmptyState({ emptyState: elements.emptyState, apiKey: state.apiKey, mode: state.mode });
+      }
+    }
+    if (showEmpty) {
+      return;
+    }
+    state.messages.forEach((message) => {
+      const bubble = document.createElement('div');
+      bubble.className = `ai-message ${message.role}`;
+      const content = document.createElement('div');
+      content.className = 'ai-markdown';
+      const allowMarkdown = message.role === 'assistant' ? state.allowMarkdown : false;
+      content.innerHTML = formatAssistantHtml(message.text, allowMarkdown);
+      bubble.appendChild(content);
+      if (message.role === 'assistant' && typeof message.proposalSectionIndex === 'number') {
+        const applyButton = document.createElement('button');
+        applyButton.type = 'button';
+        applyButton.className = 'ai-apply';
+        applyButton.textContent = 'Aplicar a la sección';
+        applyButton.addEventListener('click', () => {
+          const plain = markdownToPlainText(message.text);
+          onApplyToSection?.(message.proposalSectionIndex, plain);
+        });
+        bubble.appendChild(applyButton);
+      }
+      elements.messages.appendChild(bubble);
+    });
+    if (state.isLoading) {
+      const loading = document.createElement('div');
+      loading.className = 'ai-message assistant';
+      loading.textContent = 'Pensando...';
+      elements.messages.appendChild(loading);
+    }
+    elements.messages.scrollTop = elements.messages.scrollHeight;
+  }
+
+  function setError(message) {
+    state.error = message || '';
+    if (!elements.error) {
+      return;
+    }
+    elements.error.textContent = state.error;
+    elements.error.classList.toggle('is-visible', Boolean(state.error));
+  }
+
+  function getContext() {
+    if (typeof options.getFullContext === 'function') {
+      return options.getFullContext();
+    }
+    return buildBaseContext({
+      title: typeof getTitle === 'function' ? getTitle() : '',
+      patientFields: typeof getPatientFields === 'function' ? getPatientFields() : [],
+      sections: getSectionsData(),
+      medico: typeof getMedico === 'function' ? getMedico() : '',
+      especialidad: typeof getEspecialidad === 'function' ? getEspecialidad() : ''
+    });
+  }
+
+  function getCurrentSection() {
+    const sections = getSectionsData();
+    return sections[state.targetSectionIndex];
+  }
+
+  async function handleSend(textOverride) {
+    if (!elements.input) {
+      return;
+    }
+    const text = textOverride || elements.input.value.trim();
+    if (!text || state.isLoading || !state.apiKey) {
+      return;
+    }
+    const userMessage = {
+      id: `${Date.now()}-user`,
+      role: 'user',
+      text
+    };
+    state.messages.push(userMessage);
+    if (!textOverride) {
+      elements.input.value = '';
+    }
+    updateSendAvailability();
+    renderMessages();
+
+    const section = getCurrentSection();
+    const personaPrompt = buildSystemPrompt({ profile: state.assistantProfile, mode: state.mode, section });
+    const context = getContext();
+    const promptText =
+      state.mode === 'edit' && section
+        ? `Sección objetivo: ${section.title}\nContenido actual:\n${section.content}\n\nSolicitud: ${text}`
+        : text;
+
+    const historyPayload = state.messages.slice(-6).map((message) => ({
+      role: message.role === 'assistant' ? 'model' : 'user',
+      parts: [
+        {
+          text: message.id === userMessage.id ? promptText : message.text
+        }
+      ]
+    }));
+
+    const contents = [
+      { role: 'user', parts: [{ text: personaPrompt }] },
+      { role: 'user', parts: [{ text: `CONTEXTO CLÍNICO COMPLETO:\n${context}` }] },
+      ...historyPayload
+    ];
+
+    setError('');
+    state.isLoading = true;
+    renderMessages();
+
+    try {
+      const response = await generateGeminiContent({
+        apiKey: state.apiKey,
+        model: state.model,
+        contents,
+        projectId: state.projectId,
+        maxRetries: 1
+      });
+      const candidate = response?.candidates?.[0];
+      const replyText = candidate?.content?.parts?.map((part) => part.text || '').join('\n').trim() || 'Sin respuesta';
+      const assistantMessage = {
+        id: `${Date.now()}-assistant`,
+        role: 'assistant',
+        text: replyText,
+        proposalSectionIndex: state.mode === 'edit' ? state.targetSectionIndex : undefined
+      };
+      state.messages.push(assistantMessage);
+    } catch (error) {
+      if (error instanceof GeminiModelUnavailableError && state.autoModel) {
+        const fallback = suggestGeminiFallbackModel(error.availableModels);
+        if (fallback?.modelId) {
+          state.model = `${fallback.modelId}`;
+          persist();
+          setError('Modelo no disponible. Se seleccionó automáticamente otro modelo, intente nuevamente.');
+        } else {
+          setError(error.message || 'Modelo no disponible.');
+        }
+      } else {
+        setError(error.message || 'No se pudo completar la solicitud.');
+      }
+    } finally {
+      state.isLoading = false;
+      renderMessages();
+    }
+  }
+
+  function handleApplySectionChange(event) {
+    state.targetSectionIndex = Number(event.target.value) || 0;
+  }
+
+  function handleToggleSettings() {
+    state.showSettings = !state.showSettings;
+    if (elements.settingsPanel) {
+      elements.settingsPanel.classList.toggle('is-visible', state.showSettings);
+    }
+    persist();
+  }
+
+  function attachInputListeners() {
+    elements.apiKey?.addEventListener('input', (event) => {
+      state.apiKey = event.target.value.trim();
+      if (state.apiKey) {
+        state.showSettings = false;
+      }
+      applyPreferencesToInputs();
+      updateSendAvailability();
+      persist();
+    });
+
+    elements.project?.addEventListener('input', (event) => {
+      state.projectId = event.target.value.trim();
+      persist();
+    });
+
+    elements.model?.addEventListener('input', (event) => {
+      state.model = event.target.value.trim() || getDefaultGeminiModel();
+      persist();
+    });
+
+    elements.profile?.addEventListener('change', (event) => {
+      state.assistantProfile = event.target.value;
+      persist();
+    });
+
+    elements.markdown?.addEventListener('change', (event) => {
+      state.allowMarkdown = event.target.checked;
+      persist();
+      renderMessages();
+    });
+
+    elements.autoModel?.addEventListener('change', (event) => {
+      state.autoModel = event.target.checked;
+      persist();
+    });
+
+    elements.sectionSelect?.addEventListener('change', handleApplySectionChange);
+
+    elements.input?.addEventListener('input', updateSendAvailability);
+    elements.input?.addEventListener('keydown', (event) => {
+      if (event.key === 'Enter' && !event.shiftKey) {
+        event.preventDefault();
+        handleSend();
+      }
+    });
+  }
+
+  function attachTabListeners() {
+    elements.tabs.forEach((tab) => {
+      tab.addEventListener('click', () => {
+        const tabMode = tab.getAttribute('data-ai-mode');
+        setMode(tabMode);
+      });
+    });
+  }
+
+  function attachDrawerListeners() {
+    toggleButton.addEventListener('click', () => toggleDrawer());
+    elements.closeButton?.addEventListener('click', () => toggleDrawer(false));
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && state.isOpen) {
+        toggleDrawer(false);
+      }
+    });
+  }
+
+  function attachSettingsListeners() {
+    elements.settingsToggle?.addEventListener('click', handleToggleSettings);
+  }
+
+  function attachActionListeners() {
+    elements.actions?.addEventListener('click', (event) => {
+      const target = event.target.closest('button');
+      if (!target || target.disabled) {
+        return;
+      }
+      event.preventDefault();
+    });
+  }
+
+  function attachSendListener() {
+    elements.sendButton?.addEventListener('click', () => handleSend());
+  }
+
+  function attachResizeListener() {
+    if (!elements.resizer) {
+      return;
+    }
+    elements.resizer.addEventListener('mousedown', (event) => {
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = state.panelWidth;
+      function onMouseMove(moveEvent) {
+        const delta = startX - moveEvent.clientX;
+        state.panelWidth = clampWidth(startWidth + delta);
+        panel.style.width = `${state.panelWidth}px`;
+      }
+      function onMouseUp() {
+        document.removeEventListener('mousemove', onMouseMove);
+        document.removeEventListener('mouseup', onMouseUp);
+        persist();
+      }
+      document.addEventListener('mousemove', onMouseMove);
+      document.addEventListener('mouseup', onMouseUp);
+    });
+  }
+
+  function observeSections() {
+    const observer = new MutationObserver(() => {
+      if (state.isOpen) {
+        updateSectionPicker();
+      }
+    });
+    observer.observe(sectionsContainer, { childList: true, subtree: true });
+  }
+
+  applyPreferencesToInputs();
+  updateTabs();
+  updateSubtitle();
+  syncQuickActions();
+  renderMessages();
+  updateSendAvailability();
+  updateSectionPicker();
+
+  attachInputListeners();
+  attachTabListeners();
+  attachDrawerListeners();
+  attachSettingsListeners();
+  attachActionListeners();
+  attachSendListener();
+  attachResizeListener();
+  observeSections();
+
+  return {
+    toggle: toggleDrawer,
+    send: handleSend
+  };
+}

--- a/assets/js/utils/env.js
+++ b/assets/js/utils/env.js
@@ -1,0 +1,12 @@
+const DEFAULT_MODEL = 'gemini-1.5-flash-latest';
+
+export function normalizeGeminiModelId(model) {
+  if (!model) {
+    return DEFAULT_MODEL;
+  }
+  return model.replace(/^models\//, '').trim();
+}
+
+export function getDefaultGeminiModel() {
+  return DEFAULT_MODEL;
+}

--- a/assets/js/utils/geminiClient.js
+++ b/assets/js/utils/geminiClient.js
@@ -1,0 +1,70 @@
+import { normalizeGeminiModelId, getDefaultGeminiModel } from './env.js';
+
+export class GeminiModelUnavailableError extends Error {
+  constructor(message, availableModels = []) {
+    super(message);
+    this.name = 'GeminiModelUnavailableError';
+    this.availableModels = availableModels;
+  }
+}
+
+function buildEndpoint({ model, projectId }) {
+  const normalized = normalizeGeminiModelId(model || getDefaultGeminiModel());
+  if (projectId) {
+    return `https://generativelanguage.googleapis.com/v1beta/projects/${projectId}/locations/us-central1/models/${normalized}:generateContent`;
+  }
+  return `https://generativelanguage.googleapis.com/v1beta/models/${normalized}:generateContent`;
+}
+
+async function requestGemini({ apiKey, model, contents, projectId }) {
+  const endpoint = buildEndpoint({ model, projectId });
+  const url = `${endpoint}?key=${encodeURIComponent(apiKey)}`;
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ contents })
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    if (payload?.error?.status === 'NOT_FOUND') {
+      throw new GeminiModelUnavailableError(payload?.error?.message || 'Modelo no disponible', payload?.error?.details || []);
+    }
+    const errMsg = payload?.error?.message || 'No se pudo generar la respuesta de Gemini.';
+    throw new Error(errMsg);
+  }
+  return payload;
+}
+
+export async function generateGeminiContent({ apiKey, model, contents, projectId, maxRetries = 0 }) {
+  if (!apiKey) {
+    throw new Error('API Key no configurada.');
+  }
+  let lastError;
+  for (let attempt = 0; attempt <= maxRetries; attempt += 1) {
+    try {
+      return await requestGemini({ apiKey, model, contents, projectId });
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError;
+}
+
+const FALLBACK_ORDER = [
+  'gemini-1.5-flash-latest',
+  'gemini-1.5-flash',
+  'gemini-1.5-pro-latest',
+  'gemini-pro'
+];
+
+export function suggestGeminiFallbackModel(models = []) {
+  if (!Array.isArray(models) || !models.length) {
+    return { modelId: FALLBACK_ORDER[0], version: 'latest' };
+  }
+  const normalized = models.map((model) => (typeof model === 'string' ? model : model?.model || '')).filter(Boolean);
+  const preferred = FALLBACK_ORDER.find((modelId) => normalized.includes(modelId));
+  if (preferred) {
+    return { modelId: preferred, version: 'latest' };
+  }
+  return { modelId: FALLBACK_ORDER[0], version: 'latest' };
+}

--- a/assets/js/utils/textUtils.js
+++ b/assets/js/utils/textUtils.js
@@ -1,0 +1,63 @@
+const parser = typeof DOMParser !== 'undefined' ? new DOMParser() : null;
+
+function escapeHtml(text = '') {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function convertMarkdownToHtml(text = '') {
+  let html = text;
+  html = html.replace(/```[\s\S]*?```/g, (match) => {
+    const clean = match.replace(/```/g, '');
+    return `<pre class="ai-code">${clean.trim()}</pre>`;
+  });
+  html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+  html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+  html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+  const listRegex = /(^|\n)[-*]\s+([^\n]+)/g;
+  if (listRegex.test(html)) {
+    html = html.replace(/(?:^|\n)([-*])\s+([^\n]+)/g, (_, __, item) => `\n<li>${item}</li>`);
+    html = html.replace(/(\n<li>.*<\/li>)/gs, (match) => `<ul>${match.replace(/\n<li>/g, '<li>')}</ul>`);
+  }
+  return html;
+}
+
+function normalizeParagraphs(html) {
+  return html
+    .split(/\n{2,}/)
+    .map((block) => block.trim())
+    .filter(Boolean)
+    .map((block) => `<p>${block.replace(/\n/g, '<br>')}</p>`)
+    .join('');
+}
+
+export function formatAssistantHtml(text = '', allowMarkdown = true) {
+  const safe = escapeHtml(text);
+  const processed = allowMarkdown ? convertMarkdownToHtml(safe) : safe;
+  return normalizeParagraphs(processed || '');
+}
+
+export function htmlToPlainText(html = '') {
+  if (!parser) {
+    return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+  }
+  const doc = parser.parseFromString(html, 'text/html');
+  return doc.body.textContent?.replace(/\s+/g, ' ').trim() || '';
+}
+
+export function markdownToPlainText(text = '') {
+  return text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/\*(.+?)\*/g, '$1')
+    .replace(/\[(.+?)\]\((.*?)\)/g, '$1')
+    .replace(/#+\s*(.+)/g, '$1')
+    .replace(/[-*]\s+/g, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
     </select>
     <button id="btnPrint" class="btn" type="button">Imprimir / Guardar PDF</button>
     <button id="toggleEdit" class="btn" type="button">Editar secciones</button>
+    <button id="toggleAI" class="btn" type="button">Panel IA</button>
     <button id="exportJson" class="btn" type="button" title="Exportar registro (.json)">Exportar</button>
     <label class="btn" for="importJson" title="Importar registro (.json)">Importar</label>
     <input id="importJson" type="file" accept="application/json" style="display:none" />
@@ -66,5 +67,86 @@
   </div>
 
   <script type="module" src="assets/js/main.js"></script>
+
+  <aside id="aiDrawer" class="ai-drawer" aria-hidden="true">
+    <div class="ai-resize-handle" data-ai-resizer></div>
+    <div class="ai-drawer-inner">
+      <header class="ai-drawer-header">
+        <div>
+          <h3 class="ai-drawer-title">Asistente IA</h3>
+          <p class="ai-drawer-subtitle" data-ai-subtitle>Analiza el caso clínico completo</p>
+        </div>
+        <div class="ai-header-actions">
+          <button class="ai-ghost-btn" type="button" data-ai-settings-toggle title="Configuración">
+            ⚙️
+          </button>
+          <button class="ai-close-btn" type="button" data-ai-close title="Cerrar panel">✕</button>
+        </div>
+      </header>
+
+      <section class="ai-panel-settings" data-ai-settings>
+        <div class="ai-settings-grid">
+          <label class="ai-field">
+            <span>API Key Gemini</span>
+            <input type="password" data-ai-api-key placeholder="AIza..." autocomplete="off" />
+          </label>
+          <label class="ai-field">
+            <span>ID de proyecto (Vertex)</span>
+            <input type="text" data-ai-project placeholder="Opcional" autocomplete="off" />
+          </label>
+          <label class="ai-field">
+            <span>Modelo preferido</span>
+            <input type="text" data-ai-model placeholder="gemini-1.5-flash-latest" autocomplete="off" />
+          </label>
+          <label class="ai-field">
+            <span>Perfil médico</span>
+            <select data-ai-profile>
+              <option value="general">👨‍⚕️ Medicina general</option>
+              <option value="urgencias">🚑 Urgencias</option>
+              <option value="pediatria">👶 Pediatría</option>
+            </select>
+          </label>
+          <label class="ai-check">
+            <input type="checkbox" data-ai-markdown checked />
+            <span>Formatear respuestas en Markdown</span>
+          </label>
+          <label class="ai-check">
+            <input type="checkbox" data-ai-auto-model checked />
+            <span>Cambiar de modelo automáticamente si falla</span>
+          </label>
+        </div>
+        <p class="ai-settings-hint">Los datos se guardan localmente en este navegador.</p>
+      </section>
+
+      <div class="ai-tabs">
+        <button class="ai-tab" data-ai-mode="chat" type="button">💬 Conversación</button>
+        <button class="ai-tab" data-ai-mode="edit" type="button">📝 Editar sección</button>
+      </div>
+
+      <section class="ai-section-picker" data-ai-section-picker>
+        <label for="aiSectionSelect">Editando sección</label>
+        <select id="aiSectionSelect" data-ai-section-select></select>
+      </section>
+
+      <div class="ai-quick-actions" data-ai-actions></div>
+
+      <div class="ai-messages" data-ai-messages>
+        <div class="ai-empty" data-ai-empty>
+          <p class="ai-empty-icon">🤖</p>
+          <p>Configura tu API Key y comienza a interactuar con el asistente.</p>
+          <p class="ai-empty-hint">La IA recibe toda la ficha clínica como contexto.</p>
+        </div>
+      </div>
+      <div class="ai-error" data-ai-error role="alert"></div>
+
+      <div class="ai-input" data-ai-input-area>
+        <textarea data-ai-input rows="2" placeholder="Haz una pregunta o pide una mejora..." spellcheck="false"></textarea>
+        <button type="button" class="ai-send" data-ai-send title="Enviar">
+          <span>Enviar</span>
+        </button>
+        <p class="ai-input-hint">Shift + Enter para nueva línea</p>
+      </div>
+    </div>
+  </aside>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an IA drawer with conversation/edit tabs, quick actions and contextual application of proposals
- wire the drawer to Gemini through a new controller and utilities for formatting, env and API handling
- refresh the README and base styles to document and support the assistant

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dd3969d78832cb6be2bdb041cd49d)